### PR TITLE
fix: faq page navbar button dark mode colour fix

### DIFF
--- a/src/Components/Navbar.tsx
+++ b/src/Components/Navbar.tsx
@@ -43,7 +43,7 @@ const pages: NavbarItems[] = [
 	{
 		pageTitle: "FAQ",
 		pageUrl: "faq",
-	}
+	},
 ]
 
 const Navbar = () => {
@@ -105,7 +105,9 @@ const Navbar = () => {
 							as={IconButton}
 							icon={<IoMenu />}
 							filter={
-								currentPath === "" || currentPath === "about"
+								currentPath === "" ||
+								currentPath === "about" ||
+								currentPath === "faq"
 									? colorMode === "light"
 										? "none"
 										: "invert(100%)"
@@ -158,7 +160,8 @@ const Navbar = () => {
 								fontSize="xl"
 								color={
 									currentPath === "" ||
-									currentPath === "about"
+									currentPath === "about" ||
+									currentPath === "faq"
 										? colorMode === "light"
 											? "black"
 											: "white"


### PR DESCRIPTION
in dark mode the navbar button on `/faq` will default to black textColour due to spaghetti code, this fixes it so that the `/faq` page is inside the whitelist for turning the textColour white when using dark theme
before:
<img width="492" height="147" alt="image" src="https://github.com/user-attachments/assets/e7bbfd82-6e35-4494-8655-850725bdd1d9" />

after:
<img width="463" height="132" alt="image" src="https://github.com/user-attachments/assets/d7ef1f30-b4d8-43d7-b195-8f25e947f3c3" />